### PR TITLE
feat: hide cursor, use vim.fn.getmousepos

### DIFF
--- a/lua/piemenu/test/helper.lua
+++ b/lua/piemenu/test/helper.lua
@@ -4,7 +4,6 @@ local plugin_name = helper.get_module_root(...)
 helper.root = helper.find_plugin_root(plugin_name)
 
 function helper.before_each()
-  require("piemenu.view.background").Background._click = function() end
 end
 
 function helper.after_each()

--- a/lua/piemenu/view/animation.lua
+++ b/lua/piemenu/view/animation.lua
@@ -9,7 +9,10 @@ Animation.__index = Animation
 M.Animation = Animation
 
 function Animation.new(items, duration)
-  vim.validate({ items = { items, "table" }, duration = { duration, "number" } })
+  vim.validate({
+    items = { items, "table" },
+    duration = { duration, "number" },
+  })
 
   local on_tick = function()
     local ok = true

--- a/lua/piemenu/view/background.lua
+++ b/lua/piemenu/view/background.lua
@@ -8,76 +8,70 @@ Background.__index = Background
 M.Background = Background
 
 function Background.open(name, position)
-  local width = vim.o.columns
-  local height = vim.o.lines - vim.o.cmdheight
+	local width = vim.o.columns
+	local height = vim.o.lines - vim.o.cmdheight
 
-  local bufnr = vim.api.nvim_create_buf(false, true)
-  local buffer_name = ("piemenu://%s"):format(name)
-  bufferlib.delete_by_name(buffer_name)
-  vim.api.nvim_buf_set_name(bufnr, buffer_name)
-  local lines = vim.fn["repeat"]({ (" "):rep(width) }, height)
-  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
-  vim.bo[bufnr].filetype = "piemenu"
-  vim.bo[bufnr].bufhidden = "wipe"
-  vim.bo[bufnr].modifiable = false
+	local bufnr = vim.api.nvim_create_buf(false, true)
+	local buffer_name = ("piemenu://%s"):format(name)
+	bufferlib.delete_by_name(buffer_name)
+	vim.api.nvim_buf_set_name(bufnr, buffer_name)
+	local lines = vim.fn["repeat"]({ (" "):rep(width) }, height)
+	vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+	vim.bo[bufnr].filetype = "piemenu"
+	vim.bo[bufnr].bufhidden = "wipe"
+	vim.bo[bufnr].modifiable = false
 
-  local window_id = vim.api.nvim_open_win(bufnr, true, {
-    width = width,
-    height = height,
-    relative = "editor",
-    row = 0,
-    col = 0,
-    external = false,
-    focusable = true,
-    style = "minimal",
-  })
-  vim.wo[window_id].winblend = 100
-  vim.wo[window_id].scrolloff = 0
-  vim.wo[window_id].sidescrolloff = 0
-  vim.api.nvim_win_set_cursor(window_id, { position[1] + 1, position[2] - 1 })
+	local window_id = vim.api.nvim_open_win(bufnr, true, {
+		width = width,
+		height = height,
+		relative = "editor",
+		row = 0,
+		col = 0,
+		external = false,
+		focusable = true,
+		style = "minimal",
+	})
+	vim.wo[window_id].winblend = 100
+	vim.wo[window_id].scrolloff = 0
+	vim.wo[window_id].sidescrolloff = 0
 
-  -- NOTE: show and move cursor to the window by <LeftDrag>
-  vim.cmd.redraw()
+	local ns = vim.api.nvim_create_namespace("piemenu")
+	vim.api.nvim_exec2("hi Cursor blend=100", { output = true })
+	vim.opt.guicursor:append("a:Cursor")
 
-  vim.api.nvim_create_autocmd({ "WinLeave", "TabLeave", "BufLeave" }, {
-    buffer = bufnr,
-    once = true,
-    callback = function()
-      require("piemenu.command").close(name)
-    end,
-  })
+	vim.api.nvim_create_autocmd({ "WinLeave", "TabLeave", "BufLeave" }, {
+		buffer = bufnr,
+		once = true,
+		callback = function()
+			require("piemenu.command").close(name)
+		end,
+	})
 
-  local ns = vim.api.nvim_create_namespace("piemenu")
-  vim.api.nvim_set_decoration_provider(ns, {
-    on_win = function(_, _, buf, topline)
-      if topline == 0 or buf ~= bufnr or not vim.api.nvim_win_is_valid(window_id) then
-        return false
-      end
-      vim.fn.winrestview({ topline = 0, leftcol = 0 })
-    end,
-  })
+	vim.api.nvim_set_decoration_provider(ns, {
+		on_win = function(_, _, buf, topline)
+			if topline == 0 or buf ~= bufnr or not vim.api.nvim_win_is_valid(window_id) then
+				return false
+			end
+			vim.fn.winrestview({ topline = 0, leftcol = 0 })
+		end,
+	})
 
-  local tbl = { window_id = window_id, _ns = ns }
-  return setmetatable(tbl, Background)
+	local tbl = { window_id = window_id, _ns = ns }
+	return setmetatable(tbl, Background)
 end
 
 function Background.close(self)
-  windowlib.safe_close(self.window_id)
-  vim.api.nvim_set_decoration_provider(self._ns, {})
+	windowlib.safe_close(self.window_id)
+	vim.opt.guicursor:remove("a:Cursor")
+	vim.api.nvim_set_decoration_provider(self._ns, {})
 end
 
 function Background.click(self)
-  self:_click()
-  if not vim.api.nvim_win_is_valid(self.window_id) then
-    return nil
-  end
-  return vim.api.nvim_win_get_cursor(self.window_id)
-end
-
-local mouse = vim.api.nvim_eval('"\\<LeftMouse>"')
--- replace on testing
-function Background._click()
-  vim.cmd.normal({ args = { mouse }, bang = true })
+	if not vim.api.nvim_win_is_valid(self.window_id) then
+		return nil
+	end
+	local mouse = vim.fn.getmousepos()
+	return { mouse.screenrow, mouse.screencol }
 end
 
 return M

--- a/lua/piemenu/view/circle.lua
+++ b/lua/piemenu/view/circle.lua
@@ -13,7 +13,10 @@ CircleTiles.__index = CircleTiles
 M.CircleTiles = CircleTiles
 
 function CircleTiles.open(defined_menus, view_setting)
-  vim.validate({ defined_menus = { defined_menus, "table" }, view_setting = { view_setting, "table" } })
+  vim.validate({
+    defined_menus = { defined_menus, "table" },
+    view_setting = { view_setting, "table" },
+  })
 
   local start_angle = view_setting.start_angle
   local end_angle = view_setting.end_angle
@@ -22,8 +25,7 @@ function CircleTiles.open(defined_menus, view_setting)
   local tile_height = 3
   local tile_width = view_setting.tile_width
   local origin_pos = view_setting.position
-  local overflow_angle_ranges = TileArea.new(start_angle, end_angle)
-    :calculate_overflow(radius, origin_pos, tile_width, tile_height)
+  local overflow_angle_ranges = TileArea.new(start_angle, end_angle):calculate_overflow(radius, origin_pos, tile_width, tile_height)
 
   local menus
   if #overflow_angle_ranges:list() > 0 then
@@ -51,8 +53,7 @@ function CircleTiles.open(defined_menus, view_setting)
 
     local menu = menus[i]
     if not menu:is_empty() then
-      local tile, move =
-        Tile.open(menu, current_angle, prev_angle, next_angle, radius, tile_width, tile_height, origin_pos)
+      local tile, move = Tile.open(menu, current_angle, prev_angle, next_angle, radius, tile_width, tile_height, origin_pos)
       table.insert(tiles, tile)
       table.insert(moves, move)
     end

--- a/lua/piemenu/view/init.lua
+++ b/lua/piemenu/view/init.lua
@@ -11,7 +11,10 @@ View.__index = View
 M.View = View
 
 function View.open(name, raw_setting)
-  vim.validate({ name = { name, "string" }, raw_setting = { raw_setting, "table" } })
+  vim.validate({
+    name = { name, "string" },
+    raw_setting = { raw_setting, "table" },
+  })
 
   local menus, err
   if not raw_setting.menus then


### PR DESCRIPTION
This PR allows hiding the mouse cursor in the menu, and updates the way the mouse position is fetched to use `vim.fn.getmousepos`, which is less hacky than moving the cursor on mouse move.

todo: make hiding the cursor optional